### PR TITLE
Fixed Tables plugin not loading in front-end editor

### DIFF
--- a/public/class-froala-public.php
+++ b/public/class-froala-public.php
@@ -247,6 +247,7 @@ class Froala_Editor {
 			'quote.min.js',
 			'save.min.js',
 			'special_characters.min.js',
+			'table.min.js',
 			'url.min.js',
 			'video.min.js',
 			'word_paste.min.js'


### PR DESCRIPTION
Added the table.min.js to the froala_enque_editor_plugins() function, allowing the plugin to be enqueued via $Froala_Editor->activate()